### PR TITLE
Reject whitespace in relative interpreter paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ which relexec transforms to
 
 and `exec()`s the result.
 
+Relative interpreter paths containing spaces or tabs are rejected so that
+scripts behave consistently across kernels with different shebang parsing
+rules.
+
 
 ## Installation
 

--- a/c/relexec.c
+++ b/c/relexec.c
@@ -94,6 +94,11 @@ int main(int argc, const char **argv) {
         return 2;
     }
 
+    if (strpbrk(argv[1], " \t")) {
+        fprintf(stderr, "relexec: interpreter path cannot contain whitespace\n");
+        return 2;
+    }
+
     if (strlen(argv[2]) > PATH_MAX) {
         fprintf(stderr, "relexec: path too long\n");
         return 2;

--- a/py/relexec.py
+++ b/py/relexec.py
@@ -11,11 +11,12 @@ except:
         )
     )
 
-extra_args = interp.split()
-interp = extra_args.pop(0)
+if ' ' in interp or '\t' in interp:
+    sys.exit('relexec: interpreter path cannot contain whitespace')
+
 targetdir = os.path.dirname(targetfile)
 while os.path.islink(targetfile):
     targetfile = os.path.join(targetdir, os.readlink(targetfile))
     targetdir = os.path.dirname(targetfile)
 target_interp = os.path.join(targetdir, interp)
-os.execv(target_interp, [target_interp] + extra_args + sys.argv[2:])
+os.execv(target_interp, [target_interp] + sys.argv[2:])

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,9 +1,9 @@
 use std::env;
 use std::ffi::OsString;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
-use std::os::unix::process::CommandExt;
-
 
 /// Follow symlinks starting with `link`, until a real file is found.
 fn walk_symlink(link: &Path) -> PathBuf {
@@ -11,7 +11,7 @@ fn walk_symlink(link: &Path) -> PathBuf {
 
     while let Ok(dest) = p.read_link() {
         p = p.parent().unwrap_or(&p).join(dest);
-    };
+    }
 
     p
 }
@@ -52,11 +52,13 @@ fn main() {
         }
         _ => {
             argv.next();
-            if let Err(msg) = exec_relative(
-                argv.next().unwrap(),
-                argv.next().unwrap(),
-                &argv.collect::<Vec<_>>(),
-            ) {
+            let relcmd = argv.next().unwrap();
+            if relcmd.as_bytes().iter().any(|b| *b == b' ' || *b == b'\t') {
+                eprintln!("relexec: interpreter path cannot contain whitespace");
+                process::exit(2);
+            }
+            if let Err(msg) = exec_relative(relcmd, argv.next().unwrap(), &argv.collect::<Vec<_>>())
+            {
                 eprintln!("{}", msg);
                 process::exit(127);
             }

--- a/test_relexec.py
+++ b/test_relexec.py
@@ -109,6 +109,16 @@ class RelexecTests:
             f'{self.tmp}/interp {self.tmp}/script\n'
         )
 
+    def test_reject_interpreter_path_with_whitespace(self):
+        """Relative interpreter paths containing whitespace are rejected."""
+        for whitespace in (' ', '\t'):
+            with self.subTest(whitespace=repr(whitespace)):
+                result = subprocess.run(
+                    [self.relexec, f'interp{whitespace}arg', self.script],
+                    capture_output=True,
+                )
+                self.assertEqual(result.returncode, 2)
+
     def test_exec_failure(self):
         """If relexec exits with an error if execing the interpreter fails."""
         deactivated = self.tmp / 'interp~'


### PR DESCRIPTION
## Summary
- reject relative interpreter tokens containing spaces or tabs so behavior does not depend on kernel shebang splitting rules
- keep the C, Rust, and reference Python implementations aligned on the short-term contract
- document the restriction and add shared regression coverage for both ambiguous whitespace characters

Fixes #4

## Validation
- `git diff --check`
- `rustfmt --edition 2018 --check rust/src/main.rs`


## Remote Linux validation
- `git diff --check`
- `cargo fmt --manifest-path rust/Cargo.toml -- --check`
- `python3 test_relexec.py`
